### PR TITLE
fix: adjust viewport of HTMLView

### DIFF
--- a/Sources/Components/HTMLView.swift
+++ b/Sources/Components/HTMLView.swift
@@ -8,6 +8,7 @@ struct HTMLView {
         <!doctype html>
         <html>
         <head>
+        <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width">
         </head>
         <body>

--- a/Sources/Components/HTMLView.swift
+++ b/Sources/Components/HTMLView.swift
@@ -3,6 +3,19 @@ import WebKit
 
 struct HTMLView {
     private let html: String
+    private var fullHTML: String {
+        """
+        <!doctype html>
+        <html>
+        <head>
+        <meta name="viewport" content="width=device-width">
+        </head>
+        <body>
+        \(self.html)
+        </body>
+        </html>
+        """
+    }
 
     init(_ html: String) {
         self.html = html
@@ -17,7 +30,7 @@ extension HTMLView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: Self.UIViewType, context: Self.Context) {
-        uiView.loadHTMLString(self.html, baseURL: nil)
+        uiView.loadHTMLString(self.fullHTML, baseURL: nil)
     }
 }
 


### PR DESCRIPTION
This fixes the issue that font sizes are too small when the window width is small.