### PR TITLE
fix: fix compile errors in Swift 6 mode

### DIFF
--- a/Sources/Components/Buttons/UnitTestsButton.swift
+++ b/Sources/Components/Buttons/UnitTestsButton.swift
@@ -1,6 +1,6 @@
 #if TESTING_ENABLED
 
-    import PlaygroundTester
+    @preconcurrency import PlaygroundTester
     import SwiftUI
 
     struct UnitTestsButton {

--- a/Sources/Components/CodeEditor.swift
+++ b/Sources/Components/CodeEditor.swift
@@ -1,4 +1,4 @@
-import CodeEditorView
+@preconcurrency import CodeEditorView
 import SwiftUI
 
 struct CodeEditor {


### PR DESCRIPTION
In Swift 6 mode, these files cannot be compiled. Swift Playgrounds 4.6 does not support Swift 6 mode yet, but I will fix them for the future.