### PR TITLE
build: bump deployment target to 18.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import PackageDescription
 let package = Package(
     name: "DevToys.swiftpm",
     platforms: [
-        .iOS("17.2")
+        .iOS("18.1")
     ],
     products: [],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ This app is a SwiftUI reimplementation of [DevToys](https://devtoys.app), a Swis
 
 ## Target platforms
 
-- iPadOS 17.2 or later
-- iOS 17.2 or later
+- iPadOS 18.1 or later
+- iOS 18.1 or later
   
 ## Build requirements
 
-- Swift Playground 4.6 or later (iPadOS 17.2 or later)
+- Swift Playground 4.6 or later (iPadOS 18.1 or later)
 - Swift Playground 4.6 or later (macOS 14.0 or later)
-- Xcode 16.0 or later (macOS 14.5 or later)
+- Xcode 16.1 or later (macOS 14.5 or later)
+>>>>>>> bce72f0
 
 ## Get Started
 


### PR DESCRIPTION
Swift Playgrounds 4.6's default template is targeting iPadOS 18.1.

As I'm developing DevToys.swiftpm with Swift Playgrounds, I can't test it with old OSes on simulators. So I don't support old OSes.