### PR TITLE
refactor: replace the deprecated `String.init` with the new one

### DIFF
--- a/Sources/Components/Buttons/OpenFileButton.swift
+++ b/Sources/Components/Buttons/OpenFileButton.swift
@@ -11,7 +11,8 @@ struct OpenFileButton {
         }
         defer { url.stopAccessingSecurityScopedResource() }
         do {
-            self.text = try .init(contentsOf: url)
+            var enc: String.Encoding = .utf8
+            self.text = try .init(contentsOf: url, usedEncoding: &enc)
         } catch {
             logger.error("\(error.localizedDescription)")
             return


### PR DESCRIPTION
API references:

- old (deprecated): https://developer.apple.com/documentation/swift/string/init(contentsof:)
- new: https://developer.apple.com/documentation/swift/string/init(contentsof:usedencoding:)

There is also `String.init(contentsOf:encoding:)`, but it seems that the old `String(contentsOf:)` is equivalent to `String.init(contentsOf:usedEncoding)`.

source: https://forums.swift.org/t/what-is-the-default-encoding-of-string-contentsof/38406/2

Known issues:

- #91