### PR TITLE
feat: add support for Japanese character encodings

### DIFF
--- a/Sources/Components/Buttons/OpenFileButton.swift
+++ b/Sources/Components/Buttons/OpenFileButton.swift
@@ -3,6 +3,14 @@ import SwiftUI
 struct OpenFileButton {
     @Binding var text: String
     @State private var isImporterPresented = false
+    @State private var fileToBeOpenedWithEncoding: URL?
+
+    var encodingPickerPresented: Binding<Bool> {
+        .init(
+            get: { self.fileToBeOpenedWithEncoding != nil },
+            set: { if !$0 { self.fileToBeOpenedWithEncoding = nil } }
+        )
+    }
 
     private func openFile(_ url: URL) {
         guard url.startAccessingSecurityScopedResource() else {
@@ -13,9 +21,40 @@ struct OpenFileButton {
         do {
             var enc: String.Encoding = .utf8
             self.text = try .init(contentsOf: url, usedEncoding: &enc)
+        } catch CocoaError.fileReadCorruptFile {
+            self.fileToBeOpenedWithEncoding = url
         } catch {
             logger.error("\(error.localizedDescription)")
+        }
+    }
+
+    private func openFile(_ url: URL, using encoding: String.Encoding) {
+        guard url.startAccessingSecurityScopedResource() else {
+            logger.error("Failed to start accessing security scoped resource.")
             return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        do {
+            self.text = try String(contentsOf: url, encoding: encoding)
+        } catch {
+            logger.error("\(error.localizedDescription)")
+        }
+    }
+
+    private func openUnknownEncodingFile(_ url: URL) {
+        guard url.startAccessingSecurityScopedResource() else {
+            logger.error("Failed to start accessing security scoped resource.")
+            return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        let firstResult = String.availableStringEncodings.lazy
+            .compactMap { try? String(contentsOf: url, encoding: $0) }
+            .first
+        if let firstResult {
+            self.text = firstResult
+        } else {
+            let error = CocoaError(.fileReadCorruptFile) as NSError
+            logger.error("\(error.localizedDescription)")
         }
     }
 }
@@ -40,6 +79,31 @@ extension OpenFileButton: View {
             case .failure(let error):
                 logger.error("\(error.localizedDescription)")
             }
+        }
+        .alert(
+            "Choose Character Encoding",
+            isPresented: self.encodingPickerPresented,
+            presenting: self.fileToBeOpenedWithEncoding
+        ) { url in
+            Button("Shift_JIS") {
+                self.openFile(url, using: .shiftJIS)
+            }
+            Button("EUC-JP") {
+                self.openFile(url, using: .japaneseEUC)
+            }
+            Button("ISO-2022-JP") {
+                self.openFile(url, using: .iso2022JP)
+            }
+            Button("ASCII") {
+                self.openFile(url, using: .ascii)
+            }
+            Button("Non-lossy ASCII") {
+                self.openFile(url, using: .nonLossyASCII)
+            }
+            Button("Automatic") {
+                self.openUnknownEncodingFile(url)
+            }
+            Button("Cancel", role: .cancel) {}
         }
     }
 }


### PR DESCRIPTION
fixes #91

I improved support of `OpenFileButton` for Japanese character encodings.

- If the file has string encoding attribute data,
  - DevToys will open the file with the correct encoding.
- If the file doesn't have string encoding attribute data,
  - If the user choose "Automatic",
    - DevToys will try to find the encoding that doesn't occur an error, and try to open the file with it.
  - If the user choose one of the other encoding options,
    - DevToys will try to open the file with it.

![image](https://github.com/user-attachments/assets/d41920fa-58f3-4999-a432-1badf180eaa7)
