### PR TITLE
fix: fix `PasteButton` behavior when the pasteboard is empty

### DIFF
--- a/Sources/Components/Buttons/PasteButton.swift
+++ b/Sources/Components/Buttons/PasteButton.swift
@@ -9,7 +9,9 @@ struct PasteButton {
 extension PasteButton: View {
     var body: some View {
         Button {
-            self.text = UIPasteboard.general.string ?? ""
+            if let text = UIPasteboard.general.string {
+                self.text = text
+            }
         } label: {
             if self.hSizeClass == .compact {
                 self.label.labelStyle(.iconOnly)


### PR DESCRIPTION
This PR fixes the issue that the `PasteButton` clears a text field when pressing it when the systemwide general pasteboard doesn't have any text.