### PR TITLE
fix: use swift-log-playground only if running on Swift Playground or Xcode Previews

### DIFF
--- a/Sources/DevToysApp.swift
+++ b/Sources/DevToysApp.swift
@@ -7,7 +7,10 @@ let logger = Logger(label: "main")
 @main
 struct DevToysApp {
     init() {
-        LoggingSystem.bootstrap { PlaygroundHandler(label: $0) }
+        // Use swift-log-playground only if running on Swift Playground or Xcode Previews
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+            LoggingSystem.bootstrap { PlaygroundHandler(label: $0) }
+        }
     }
 }
 


### PR DESCRIPTION
https://github.com/kkebo/swift-log-playground/pull/20