### PR TITLE
fix: hide Debug section if the app is installed from an ipa file

### DIFF
--- a/Sources/Sidebar.swift
+++ b/Sources/Sidebar.swift
@@ -58,11 +58,13 @@ extension Sidebar: View {
             }
         }
         #if DEBUG
-            Section("Debug") {
-                #if TESTING_ENABLED
-                    UnitTestsButton()
-                #endif
-                ExportIPAButton()
+            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+                Section("Debug") {
+                    #if TESTING_ENABLED
+                        UnitTestsButton()
+                    #endif
+                    ExportIPAButton()
+                }
             }
         #endif
     }


### PR DESCRIPTION
If I generate an ipa file from the "Generate IPA" button on the sidebar, it's built with the debug build. So it shows the "Debug" section. It's only needed when running on Swift Playground. So I've decided to hide it when the app is built with the debug build but is not running on Swift Playground.