### PR TITLE
fix: disable Copy and Save buttons when the text is empty

### DIFF
--- a/Sources/Components/Buttons/CopyButton.swift
+++ b/Sources/Components/Buttons/CopyButton.swift
@@ -19,6 +19,7 @@ extension CopyButton: View {
         }
         .buttonStyle(.bordered)
         .hoverEffect()
+        .disabled(self.text.isEmpty)
     }
 
     private var label: some View {

--- a/Sources/Components/Buttons/SaveFileButton.swift
+++ b/Sources/Components/Buttons/SaveFileButton.swift
@@ -18,6 +18,7 @@ extension SaveFileButton: View {
         }
         .buttonStyle(.bordered)
         .hoverEffect()
+        .disabled(self.text.isEmpty)
     }
 }
 


### PR DESCRIPTION
Being able to copy and save empty text does not make any sense.