### PR TITLE
feat: use the unified logging system on release build

### DIFF
--- a/Sources/DevToysApp.swift
+++ b/Sources/DevToysApp.swift
@@ -1,16 +1,9 @@
-import Logging
-import LoggingPlayground
 import SwiftUI
-
-let logger = Logger(label: "main")
 
 @main
 struct DevToysApp {
     init() {
-        // Use swift-log-playground only if running on Swift Playground or Xcode Previews
-        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
-            LoggingSystem.bootstrap { PlaygroundHandler(label: $0) }
-        }
+        initializeLogger()
     }
 }
 

--- a/Sources/Models/logger.swift
+++ b/Sources/Models/logger.swift
@@ -1,0 +1,21 @@
+#if DEBUG
+    import Logging
+    import LoggingPlayground
+
+    import class Foundation.ProcessInfo
+
+    let logger = Logger(label: "main")
+#else
+    import os.log
+
+    let logger = Logger()
+#endif
+
+func initializeLogger() {
+    #if DEBUG
+        // Use swift-log-playground only if running on Swift Playground or Xcode Previews
+        if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+            LoggingSystem.bootstrap { PlaygroundHandler(label: $0) }
+        }
+    #endif
+}


### PR DESCRIPTION
Since we're developing this app on Swift Playground, we are currently using swift-log-playground based on swift-log. However, the unified logging system is better option in other situations. So I've decided to use it on release build.